### PR TITLE
[WIP] - initial refactoring into a package

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -17,12 +17,11 @@ package cmd
 import (
 	// "bytes"
 	// "fmt"
-	"io/ioutil"
-	// "crypto/tls"
+	"io/ioutil" // "crypto/tls"
 	// "encoding/json"
-	"log"
-	// "net/http"
+	"log" // "net/http"
 
+	"github.com/dcos-labs/dcos-auth/pkg/dcosauth"
 	"github.com/spf13/cobra"
 )
 
@@ -47,14 +46,14 @@ var loginCmd = &cobra.Command{
 		}
 
 		// Returns a []byte
-		loginObject, err := generateServiceLoginObject(privateKey, uid, validTime)
+		loginObject, err := dcosauth.GenerateServiceLoginObject(privateKey, uid, validTime)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		authToken, err := login(master, loginObject)
+		authToken, err := dcosauth.Login(master, loginObject)
 
-		err = output([]byte(authToken))
+		err = dcosauth.Output([]byte(authToken), outputFile)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/refresh.go
+++ b/cmd/refresh.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"log"
 
+	"github.com/dcos-labs/dcos-auth/pkg/dcosauth"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +40,7 @@ var refreshCmd = &cobra.Command{
 			// File does not exist; let's write to it
 			refresh = true
 		} else {
-			refresh, err = checkExpired(string(tokenString))
+			refresh, err = dcosauth.CheckExpired(string(tokenString), refreshThreshold)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -52,14 +53,14 @@ var refreshCmd = &cobra.Command{
 			}
 
 			// Returns a []byte
-			loginObject, err := generateServiceLoginObject(privateKey, uid, validTime)
+			loginObject, err := dcosauth.GenerateServiceLoginObject(privateKey, uid, validTime)
 			if err != nil {
 				log.Fatal(err)
 			}
 
-			authToken, err := login(master, loginObject)
+			authToken, err := dcosauth.Login(master, loginObject)
 
-			err = output([]byte(authToken))
+			err = dcosauth.Output([]byte(authToken), outputFile)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"log"
 
+	"github.com/dcos-labs/dcos-auth/pkg/dcosauth"
 	"github.com/spf13/cobra"
 )
 
@@ -39,13 +40,13 @@ var genSLTCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		loginToken, err := generateServiceLoginToken(privateKey, uid, validTime)
+		loginToken, err := dcosauth.GenerateServiceLoginToken(privateKey, uid, validTime)
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		// fmt.Println(string(loginObject))
-		err = output([]byte(loginToken))
+		err = dcosauth.Output([]byte(loginToken), outputFile)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -68,12 +69,12 @@ var genSLOCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		loginObject, err := generateServiceLoginObject(privateKey, uid, validTime)
+		loginObject, err := dcosauth.GenerateServiceLoginObject(privateKey, uid, validTime)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		err = output(loginObject)
+		err = dcosauth.Output(loginObject, outputFile)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/dcosauth/dcosauth.go
+++ b/pkg/dcosauth/dcosauth.go
@@ -1,4 +1,4 @@
-package cmd
+package dcosauth
 
 import (
 	"bytes"
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 )
 
 type serviceLoginObject struct {
@@ -49,7 +49,7 @@ func createClient() *http.Client {
 	return client
 }
 
-func checkExpired(tokenString string) (expired bool, err error) {
+func CheckExpired(tokenString string, refreshThreshold int) (expired bool, err error) {
 	b64claims := strings.Split(tokenString, ".")[1]
 
 	claimsJson, err := base64.RawStdEncoding.DecodeString(b64claims)
@@ -70,7 +70,7 @@ func checkExpired(tokenString string) (expired bool, err error) {
 	return float64(claims.Exp) < minValidTime, nil
 }
 
-func login(master string, loginObject []byte) (authToken string, err error) {
+func Login(master string, loginObject []byte) (authToken string, err error) {
 
 	// Build client
 	client := createClient()
@@ -113,7 +113,7 @@ func login(master string, loginObject []byte) (authToken string, err error) {
 }
 
 // TODO: Add optional additional claims
-func generateServiceLoginToken(privateKey []byte, uid string, validTime int) (loginToken string, err error) {
+func GenerateServiceLoginToken(privateKey []byte, uid string, validTime int) (loginToken string, err error) {
 	// Parse the key
 	key, err := jwt.ParseRSAPrivateKeyFromPEM(privateKey)
 	if err != nil {
@@ -130,8 +130,8 @@ func generateServiceLoginToken(privateKey []byte, uid string, validTime int) (lo
 	return token.SignedString(key)
 }
 
-func generateServiceLoginObject(privateKey []byte, uid string, validTime int) (loginObject []byte, err error) {
-	token, err := generateServiceLoginToken(privateKey, uid, validTime)
+func GenerateServiceLoginObject(privateKey []byte, uid string, validTime int) (loginObject []byte, err error) {
+	token, err := GenerateServiceLoginToken(privateKey, uid, validTime)
 
 	m := serviceLoginObject{
 		Uid:   uid,
@@ -141,7 +141,7 @@ func generateServiceLoginObject(privateKey []byte, uid string, validTime int) (l
 	return json.Marshal(m)
 }
 
-func output(content []byte) (err error) {
+func Output(content []byte, outputFile string) (err error) {
 	err = nil
 	if outputFile != "" {
 		err = ioutil.WriteFile(outputFile, []byte(content), 0600)


### PR DESCRIPTION
* Moved everything from `util.go` in the `cmd` package into a new `dcosauth` package in `/pkg`. 
* Made necessary functions exportable
* Confirmed cli functionality didn't change.

Still needed (at a minimum):
- [ ] comment exported functions
- [ ] refactor for testability (for instance, to mock the API responses to test the `Login` and `Refresh` function, and to mock reading the key file)
- [ ] internalize things that don't need to be external
- [ ] lots of code repeat everywhere